### PR TITLE
biter_station: skip waiver lookup when the module item is absent

### DIFF
--- a/feature_flags.lua
+++ b/feature_flags.lua
@@ -67,4 +67,15 @@ function M.entity_prototype_exists(name)
   return prototypes.entity[name] ~= nil
 end
 
+-- Module items are gated behind feature flags (working hours, Space Age), so
+-- a saved game can run this code with the prototype absent. get_item_count
+-- errors on an unknown item name rather than returning 0, so callers that
+-- look for an optional item must check existence first.
+function M.item_prototype_exists(name)
+  if not (prototypes and prototypes.item) then
+    return true
+  end
+  return prototypes.item[name] ~= nil
+end
+
 return M

--- a/scripts/biter_station.lua
+++ b/scripts/biter_station.lua
@@ -1,6 +1,7 @@
 local C = require("scripts.constants")
 local working_hours = require("scripts.working_hours")
 local unit_ai_settings = require("scripts.unit_ai_settings")
+local feature_flags = require("feature_flags")
 
 local M = {}
 local biters_module = nil
@@ -26,6 +27,9 @@ end
 -- permanent, but removing it immediately returns the building to dispatch.
 local function has_unstaffed_operations_waiver(entity)
   if not entity or not entity.valid or not entity.get_module_inventory then
+    return false
+  end
+  if not feature_flags.item_prototype_exists("unstaffed-operations-waiver") then
     return false
   end
   local inventory = entity.get_module_inventory()

--- a/scripts/working_hours.lua
+++ b/scripts/working_hours.lua
@@ -74,6 +74,9 @@ local function has_overtime_exemption(entity)
   if not entity or not entity.valid or not entity.get_module_inventory then
     return false
   end
+  if not feature_flags.item_prototype_exists("overtime-exemption") then
+    return false
+  end
   local inventory = entity.get_module_inventory()
   return inventory and inventory.valid and inventory.get_item_count("overtime-exemption") > 0 or false
 end

--- a/tests/test_biter_station_runtime.lua
+++ b/tests/test_biter_station_runtime.lua
@@ -586,6 +586,41 @@ test("non-returning orphaned station worker protests immediately without a host"
   assert_true(active_worker() == nil, "converted protester should leave station active worker tracking")
 end)
 
+test("managed building without the waiver item prototype does not error", function()
+  storage = {}
+  package.loaded["scripts.biter_station"] = nil
+  local surface = new_surface()
+  local force = {name = "player", valid = true, technologies = {}, set_cease_fire = function() end}
+  game = {
+    tick = 0,
+    surfaces = {surface},
+    forces = {player = force},
+    create_force = function(name)
+      local created = {name = name, valid = true, technologies = {}, set_cease_fire = function() end}
+      game.forces[name] = created
+      return created
+    end,
+  }
+  -- Space Age (or working hours) disabled: the waiver module never loads, and
+  -- the engine errors on get_item_count for an unknown item name.
+  prototypes = {item = {}}
+  local building = new_managed_building(surface, force)
+  function building.get_module_inventory()
+    return {
+      valid = true,
+      get_item_count = function(name) error("Unknown item name: " .. name) end,
+    }
+  end
+  local biter_station = require("scripts.biter_station")
+
+  biter_station.track_managed_building(building)
+
+  assert_true(storage.managed_building_registry[building.unit_number] == building,
+    "building should still be tracked when the waiver prototype is absent")
+  assert_eq(building.active, false, "building without a waiver should wait for a dispatched worker")
+  prototypes = nil
+end)
+
 print(("Biter station runtime tests: %d passed, %d failed"):format(passed, failed))
 if failed > 0 then
   for _, err in ipairs(errors) do


### PR DESCRIPTION
### Bug

Building any biter-station managed building crashes on installs without Space Age:

Error while running event administratorio::on_built_entity (ID 6)
Unknown item name: unstaffed-operations-waiver

### Cause

The waiver module is double-gated — prototypes/item.lua:25 loads item/modules only with working hours on, and prototypes/item/modules.lua:18 adds the waiver only with Space Age on. But control.lua:1174 calls biter_station.track_managed_building unconditionally, unlike working_hours.track_entity right above it. That reaches get_item_count("unstaffed-operations-waiver"), which raises on an unknown item name instead of returning 0.

has_overtime_exemption in scripts/working_hours.lua had the same latent bug with working hours off.

### Fix

New feature_flags.item_prototype_exists, mirroring the existing entity_prototype_exists, guards both module lookups: no prototype means no inventory can hold the item, so the check returns false. Fixed in the shared functions, so every caller is covered.

Regression test in tests/test_biter_station_runtime.lua reproduces the crash without the guard and passes with it. Full Lua suite green.