### PR TITLE
compat: hook engine for other-mod compatibility, plus day/night inside sealed interiors

### DIFF
--- a/Internal/docs/index.md
+++ b/Internal/docs/index.md
@@ -12,6 +12,7 @@ An overhaul mod for Factorio 2.0 that replaces military conflict with corporate 
 - **[Biter Employment](biter-employment.md)** — Hiring workers, the Biter Employment Office (station), Biterport (walking-worker roboport), and Field Office.
 - **[Buildings & Structures](buildings-and-structures.md)** — All buildings, production facilities, administrative buildings, pneumatic tube network, and support structures.
 - **[Technology Tree](technology-tree.md)** — Complete tech tree from discovery triggers through Constitutional Law, including specialization training and capacity upgrades.
+- **[Mod Compatibility](mod-compatibility.md)** — For contributors: the `compat/` hook engine, existing hook points, and how to add compatibility with another mod without touching core logic.
 - **[Advanced Topics](advanced-topics.md)** — Hired Biter (field agents), working hours system, modules, funding chain, coffee economy, train transit, and structural bottlenecks.
 
 ## Current State

--- a/Internal/docs/mod-compatibility.md
+++ b/Internal/docs/mod-compatibility.md
@@ -1,0 +1,152 @@
+# Mod Compatibility Engine
+
+How Administratorio integrates with other mods, and how to add an integration
+of your own without editing core logic.
+
+Everything lives under `compat/`:
+
+```
+compat/
+  hooks.lua                 the engine: register / resolve / collect
+  init.lua                  the static list of compat modules and their stages
+  factorissimo/
+    data.lua                data-stage half (prototype changes)
+    runtime.lua             control-stage half (remote calls, hook answers)
+```
+
+## The idea
+
+Core modules never name another mod. Instead they read a **hook point** — a
+named question with a default answer of their own:
+
+```lua
+-- scripts/working_hours.lua
+local outside, dark = hooks.resolve("time_of_day_surface", surface, position)
+if outside == nil then return surface, false end   -- nobody answered
+```
+
+A compat module answers that question at load time:
+
+```lua
+-- compat/factorissimo/runtime.lua
+hooks.register("time_of_day_surface", function(surface, position)
+  if not M.available() then return nil end        -- "not my case"
+  ...
+  return outside, unlit
+end)
+```
+
+With no compat module registered, `resolve` returns `nil` and the core keeps
+its own answer, so the vanilla path costs one table lookup and stays exactly as
+it was before the hook existed.
+
+The seam in the core is the only part that cannot be avoided: Lua locals cannot
+be patched from outside a file, `script.on_event` allows one handler per event
+per mod, and Factorio cannot enumerate a directory. So extension points are
+authored, not injected. **A new mod that fits an existing point costs zero lines
+outside `compat/`. A new *kind* of interference costs one seam.**
+
+## The two kinds of hook
+
+### `resolve(point, ...)` — ask for one answer
+
+Handlers are tried in registration order; the first one returning a non-`nil`
+first value wins, and its second return value comes along. `nil` means "not my
+case", which is what lets several mods share one point without fighting.
+
+Use it for a decision that depends on runtime state.
+
+### `collect(point, base)` — merge sets once, at load time
+
+Every handler returns a table; all of them are merged into `base`, which is
+returned. The result is a plain table, so a hot loop keeps indexing it directly
+with no call overhead.
+
+Use it for whitelists, blacklists, name sets — anything read on every tick.
+
+Because `collect` runs while the core module is loading, registration has to
+happen first. `compat.init` is required at the top of `control.lua` for exactly
+that reason, and registering into a point that was already read raises an error
+instead of being silently dropped — a silent misordering would silently disable
+compatibility.
+
+## Existing hook points
+
+| Point | Kind | Question | Answer |
+| --- | --- | --- | --- |
+| `time_of_day_surface` | `resolve` | Which surface carries the real time of day for a building at `(surface, position)`, and is the spot dark whatever that surface says? | `surface, dark` — or `nil` to fall through |
+| `tube_traversable_entities` | `collect` | Which foreign entities may a pneumatic tube network walk through? | `{[entity_name] = true}` |
+
+`time_of_day_surface` exists because a mod can freeze the daytime of a surface
+it owns. Factorissimo does: a factory floor sits at noon with the interior
+lights upgrade and at midnight without, both with `freeze_daytime`, so a
+day-gated building inside a factory would otherwise never see night. The
+Factorissimo handler walks out to the enclosing factory's outside surface,
+through nested factories, and reports a factory without the lights upgrade as
+dark.
+
+`tube_traversable_entities` exists because widening a foreign entity to accept
+the `pneumatic-forms` connection category — which `compat/factorissimo/data.lua`
+does to the factory wall pumps — also has to tell the tube BFS that the entity
+is safe to walk through. Without that, a water pipe behind such an entity would
+drag the whole fluid grid into the tube network.
+
+## Adding your own compatibility
+
+1. **Create `compat/<mod>/`.** Use `data.lua` for prototype changes and
+   `runtime.lua` for control-stage code. Keep them separate files: the two
+   stages never share a Lua state, and a single file would need stage guards.
+
+2. **Register the directory in `compat/init.lua`:**
+
+   ```lua
+   local COMPAT = {
+     {mod = "factorissimo", stages = {data = true, runtime = true}},
+     {mod = "yourmod",      stages = {runtime = true}},
+   }
+   ```
+
+   Only declare the stages whose files actually exist; a missing file is a load
+   error, on purpose.
+
+3. **Gate the module on its mod being present.** Do it inside the module, never
+   in `init.lua`. Both of these are fine:
+
+   ```lua
+   if not (data.raw.pump and data.raw.pump["their-entity"]) then return end  -- data stage
+   if not remote.interfaces["theirmod"] then return nil end                  -- runtime
+   ```
+
+   When you call a remote interface, check that the methods you use are actually
+   in it, not just the interface itself — an older release of the same mod may
+   not expose them, and a missing method is a crash inside `remote.call`.
+
+4. **Answer a hook point** with `hooks.register(point, handler)`. Return `nil`
+   from a `resolve` handler for any case you do not claim.
+
+5. **If no point fits,** add one. That is the only change a compat module may
+   ask of a core file:
+
+   - Pick a name describing the *question*, not the mod. `time_of_day_surface`,
+     not `factorissimo_interior`.
+   - Put the call at the place where the decision is actually made, and keep the
+     vanilla answer in the core as the fallback.
+   - Document the point in the table above.
+
+6. **Write a test.** `tests/test_factorissimo_compat.lua` is the pattern: mock
+   `remote`, assert what the handler answers, and assert that requiring the
+   module registers it. `tests/test_compat_hooks.lua` covers the engine itself.
+   Tests that load a core module reading a `collect` point must load
+   `compat.init` first, the same order `control.lua` uses.
+
+## Things the engine deliberately does not do
+
+- **No event dispatcher.** Factorissimo has one (`lib/events.lua`) because its
+  compat files need their own event subscriptions. None of ours do yet. When one
+  does, the dispatcher is about twenty lines — add it then.
+- **No mod-presence helper.** Each module already has a stricter check available
+  to it (a prototype, a remote interface), and a shared `is_active()` would just
+  be a weaker duplicate.
+- **No automatic discovery.** `compat/init.lua` is a hand-maintained list
+  because the data stage cannot read a directory. Keeping the runtime list in
+  the same file keeps both stages honest about what exists.

--- a/compat/factorissimo/data.lua
+++ b/compat/factorissimo/data.lua
@@ -1,4 +1,7 @@
--- ADMINISTRATORIO: FACTORISSIMO PNEUMATIC COMPATIBILITY
+-- ADMINISTRATORIO: FACTORISSIMO PNEUMATIC COMPATIBILITY (DATA STAGE)
+--
+-- Loaded from compat/init.lua during data-final-fixes; runs on require, like
+-- every other data-stage compat module.
 --
 -- Factorissimo carries fluids through a factory wall with a pair of hidden
 -- pumps linked across surfaces.  Those pumps only accept the "default" pipe
@@ -15,8 +18,6 @@
 -- Nothing flows across such a mismatch -- tubes never carry fluid -- and the
 -- BFS whitelist in scripts/pneumatic.lua refuses to walk out of the pump into a
 -- foreign fluid network.
-
-local M = {}
 
 -- A pipeline's extent is the min extent of every fluidbox in it, measured in
 -- raw coordinates with no regard for which surface each one sits on.  A tube
@@ -40,7 +41,7 @@ local FACTORY_PUMPS = {
   "factory-outside-pump-output",
 }
 
-function M.apply(data)
+local function apply()
   local pumps = data.raw.pump
   if not (pumps and pumps["factory-inside-pump-input"]) then return end -- no Factorissimo
 
@@ -68,4 +69,4 @@ function M.apply(data)
   end
 end
 
-return M
+apply()

--- a/compat/factorissimo/runtime.lua
+++ b/compat/factorissimo/runtime.lua
@@ -7,6 +7,68 @@
 
 local hooks = require("compat.hooks")
 
+local M = {}
+
+local INTERFACE = "factorissimo"
+local LIGHTS_TECH = "factory-interior-upgrade-lights"
+-- Factorissimo 2 releases predate these; without them we behave as if the mod
+-- were absent rather than crash inside remote.call.
+local REQUIRED_METHODS = {
+  "is_factorissimo_surface",
+  "find_surrounding_factory_by_surface_index",
+}
+-- ponytail: nesting cap, a factory nested deeper keeps the inner answer
+local MAX_NESTING = 8
+
+function M.available()
+  local interface = remote and remote.interfaces and remote.interfaces[INTERFACE]
+  if not interface then return false end
+  for _, method in ipairs(REQUIRED_METHODS) do
+    if not interface[method] then return false end
+  end
+  return true
+end
+
+--- Walks out of a factory to the surface that carries the real time of day.
+--- Factorissimo freezes the daytime of a factory floor (noon with the interior
+--- lights upgrade, midnight without), so a building inside never sees the day
+--- and night of the planet its factory stands on.
+---
+--- Returns the outermost surface plus an "unlit" flag: a factory without the
+--- interior lights upgrade is genuinely dark, and the caller should treat it as
+--- night whatever the surface says. Surfaces outside a factory come back
+--- unchanged, so callers need no Factorissimo check of their own.
+function M.resolve_outside_surface(surface, position)
+  if not (surface and surface.valid) then return surface, false end
+  if not position or not M.available() then return surface, false end
+
+  for _ = 1, MAX_NESTING do
+    if not remote.call(INTERFACE, "is_factorissimo_surface", surface.index) then break end
+    local factory = remote.call(INTERFACE, "find_surrounding_factory_by_surface_index", surface.index, position)
+    if not factory then break end
+
+    local force = factory.force
+    local lights = force and force.valid and force.technologies[LIGHTS_TECH]
+    if not (lights and lights.researched) then return surface, true end
+
+    local outside = factory.outside_surface
+    if not (outside and outside.valid) then break end
+    surface = outside
+    position = {x = factory.outside_x, y = factory.outside_y}
+  end
+
+  return surface, false
+end
+
+-- Returning nil means "not my case": the core keeps its own answer and the next
+-- handler, if any, gets a turn.
+hooks.register("time_of_day_surface", function(surface, position)
+  if not M.available() then return nil end
+  local outside, unlit = M.resolve_outside_surface(surface, position)
+  if outside == surface and not unlit then return nil end
+  return outside, unlit
+end)
+
 -- The wall pumps accept our connection category because of data.lua, so the
 -- tube network has to be told they are safe to walk through.  Not gated on the
 -- mod being present: an entry for an entity that does not exist is inert, and
@@ -19,3 +81,5 @@ hooks.register("tube_traversable_entities", function()
     ["factory-outside-pump-output"] = true,
   }
 end)
+
+return M

--- a/compat/factorissimo/runtime.lua
+++ b/compat/factorissimo/runtime.lua
@@ -1,0 +1,21 @@
+-- ADMINISTRATORIO: FACTORISSIMO RUNTIME COMPATIBILITY
+--
+-- Control-stage half of the Factorissimo compatibility, loaded from
+-- compat/init.lua.  The data-stage half -- the pneumatic tube patch for the
+-- wall pumps -- sits next door in data.lua; the two never share a Lua state,
+-- hence the two files.
+
+local hooks = require("compat.hooks")
+
+-- The wall pumps accept our connection category because of data.lua, so the
+-- tube network has to be told they are safe to walk through.  Not gated on the
+-- mod being present: an entry for an entity that does not exist is inert, and
+-- remote interfaces are not up yet at load time anyway.
+hooks.register("tube_traversable_entities", function()
+  return {
+    ["factory-inside-pump-input"] = true,
+    ["factory-inside-pump-output"] = true,
+    ["factory-outside-pump-input"] = true,
+    ["factory-outside-pump-output"] = true,
+  }
+end)

--- a/compat/hooks.lua
+++ b/compat/hooks.lua
@@ -1,0 +1,60 @@
+-- ADMINISTRATORIO: COMPATIBILITY HOOKS
+--
+-- Named extension points.  Compat modules register handlers at load time; the
+-- core reads a point without knowing who, if anyone, answered.  Nothing here
+-- knows about any particular mod, and no core module names one.
+
+local M = {}
+
+local handlers = {}  -- point -> ordered list of handlers
+local sealed = {}    -- point -> true once its value has been read
+
+--- Registration order is the require order in compat/init.lua: deterministic,
+--- and identical for every peer in a multiplayer game.
+function M.register(point, handler)
+  if sealed[point] then
+    -- A silent misordering would silently disable compatibility, so this is a
+    -- hard error: compat.init must load before whatever reads the point.
+    error("compat hook '" .. point .. "' was already read before this registration")
+  end
+  local list = handlers[point]
+  if not list then
+    list = {}
+    handlers[point] = list
+  end
+  list[#list + 1] = handler
+  return M
+end
+
+--- Ask a point for an answer.  The first handler returning non-nil wins; nil
+--- when nobody claims the case, so the caller keeps its own default.
+function M.resolve(point, ...)
+  sealed[point] = true
+  local list = handlers[point]
+  if not list then return nil end
+  for i = 1, #list do
+    local answer, extra = list[i](...)
+    if answer ~= nil then return answer, extra end
+  end
+  return nil
+end
+
+--- Union of `base` with every registered set.  Read once, at load time, so the
+--- result stays a plain table the caller can index in a hot loop.
+function M.collect(point, base)
+  sealed[point] = true
+  for _, handler in ipairs(handlers[point] or {}) do
+    for key, value in pairs(handler()) do
+      base[key] = value
+    end
+  end
+  return base
+end
+
+--- Tests only: forget every registration.
+function M.reset()
+  handlers = {}
+  sealed = {}
+end
+
+return M

--- a/compat/init.lua
+++ b/compat/init.lua
@@ -1,0 +1,27 @@
+-- ADMINISTRATORIO: COMPATIBILITY LOADER
+--
+-- Factorio cannot enumerate a directory, so every compat module is named here.
+-- This list only says which files exist and in which stage they run; each
+-- module gates itself on its own mod being present.
+--
+-- Adding compatibility with another mod means adding a directory under compat/
+-- and one line below.  Core modules stay untouched as long as the new module
+-- fits an existing hook point in compat/hooks.lua.
+
+local COMPAT = {
+  {mod = "factorissimo", stages = {data = true, runtime = true}},
+}
+
+local M = {}
+
+--- stage is "data" (called from data-final-fixes) or "runtime" (from control).
+--- Must run before any module that reads a hook point.
+function M.load(stage)
+  for _, entry in ipairs(COMPAT) do
+    if entry.stages[stage] then
+      require("compat." .. entry.mod .. "." .. stage)
+    end
+  end
+end
+
+return M

--- a/control.lua
+++ b/control.lua
@@ -1,6 +1,10 @@
 -- ADMINISTRATORIO: RUNTIME ORCHESTRATOR
 -- Requires script modules and registers all event handlers.
 
+-- Compatibility modules first: they register into compat/hooks.lua, and script
+-- modules read those hook points while loading.
+require("compat.init").load("runtime")
+
 local C = require("scripts.constants")
 local pneumatic = require("scripts.pneumatic")
 local interplanetary_tube = require("scripts.interplanetary_tube")

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1622,8 +1622,7 @@ require("prototypes.final_fixes.science_pack_stripping").apply(data, ITEM_LIKE_P
 require("prototypes.final_fixes.rocket_weights").apply()
 
 -------------------------------------------------------------------------------
--- 14. FACTORISSIMO PNEUMATIC TUBE COMPATIBILITY
--- Let pneumatic tubes pass through a Factorissimo factory wall. No-op when
--- Factorissimo is absent.
+-- 14. OTHER MODS
+-- Every data-stage compatibility module, each a no-op when its mod is absent.
 -------------------------------------------------------------------------------
-require("prototypes.final_fixes.factorissimo_pneumatic").apply(data)
+require("compat.init").load("data")

--- a/scripts/biter_station.lua
+++ b/scripts/biter_station.lua
@@ -359,7 +359,7 @@ end
 local function dispatch_requires_coffee(station)
   return station and station.valid
     and working_hours.is_enabled()
-    and working_hours.is_night(station.surface)
+    and working_hours.is_night(station.surface, station.position)
 end
 
 local function available_dispatch_coffee(station)

--- a/scripts/biterport.lua
+++ b/scripts/biterport.lua
@@ -472,7 +472,7 @@ end
 local function dispatch_requires_coffee(port)
   return port and port.valid
     and working_hours.is_enabled()
-    and working_hours.is_night(port.surface)
+    and working_hours.is_night(port.surface, port.position)
 end
 
 local function available_dispatch_coffee(port)

--- a/scripts/pneumatic.lua
+++ b/scripts/pneumatic.lua
@@ -9,6 +9,7 @@
 -- into the pipe graph for BFS-based network detection.
 
 local C = require("scripts.constants")
+local hooks = require("compat.hooks")
 local M = {}
 
 -------------------------------------------------------------------------------
@@ -93,21 +94,16 @@ end
 local MAX_NETWORK_RADIUS = C.TUBE_MAX_NETWORK_RADIUS -- tiles from the starting pipe
 
 --- Entities the tube network is allowed to walk through.
---- The "pneumatic-forms" connection category normally keeps foreign fluid
---- entities out on its own, but the Factorissimo compatibility patch
---- (prototypes/final_fixes/factorissimo_pneumatic.lua) gives that mod's wall
---- pumps both the default and the pneumatic category.  Without this whitelist a
---- water pipe on the far side of such a pump would drag the entire fluid grid
---- into the tube network.
-local TRAVERSABLE_NETWORK_ENTITIES = {
+--- The "pneumatic-forms" connection category keeps foreign fluid entities out
+--- on its own.  A compat module that widens some other mod's entity to accept
+--- our category has to add that entity here as well, or a water pipe on the far
+--- side of it would drag the entire fluid grid into the tube network.
+--- Collected once, at load time, so the BFS keeps indexing a plain table.
+local TRAVERSABLE_NETWORK_ENTITIES = hooks.collect("tube_traversable_entities", {
   ["pneumatic-pipe"] = true,
   ["pneumatic-pipe-to-ground"] = true,
   ["pneumatic-hidden-network-pipe"] = true,
-  ["factory-inside-pump-input"] = true,
-  ["factory-inside-pump-output"] = true,
-  ["factory-outside-pump-input"] = true,
-  ["factory-outside-pump-output"] = true,
-}
+})
 
 --- BFS through fluidbox connections starting from a hidden network pipe.
 --- Returns network_id, over_extended.

--- a/scripts/working_hours.lua
+++ b/scripts/working_hours.lua
@@ -1,5 +1,6 @@
 local M = {}
 local feature_flags = require("feature_flags")
+local hooks = require("compat.hooks")
 local WORKING_HOURS_ENABLED = feature_flags.working_hours_enabled()
 
 local MANAGED_BUILDINGS = {
@@ -59,15 +60,31 @@ local function clear_visual_state(entity, state)
   end
 end
 
-local function is_surface_night(surface)
-  if not surface or not surface.valid then return false end
-
-  local daytime = surface.daytime
+local function surface_daytime_is_night(surface)
   if surface.dusk == surface.dawn then
     return false
   end
   -- 30% of the day closed, centered on midnight (0.5)
+  local daytime = surface.daytime
   return daytime >= 0.35 and daytime < 0.65
+end
+
+-- Some mods put buildings on a surface whose time of day is frozen -- a sealed
+-- factory interior, for one -- so ask which surface carries the real time of
+-- day, and whether the spot is dark whatever that surface says. Falling through
+-- to this surface is the vanilla answer.
+local function time_of_day_surface(surface, position)
+  local outside, dark = hooks.resolve("time_of_day_surface", surface, position)
+  if outside == nil then return surface, false end
+  return outside, dark or false
+end
+
+local function is_surface_night(surface, position)
+  if not surface or not surface.valid then return false end
+
+  local outside, dark = time_of_day_surface(surface, position)
+  if dark then return true end
+  return surface_daytime_is_night(outside)
 end
 
 local function has_overtime_exemption(entity)
@@ -251,7 +268,7 @@ function M.refresh_entity(entity)
   if entity_is_protested(entity) then
     reason = "protest"
   elseif requires_overtime_exemption(entity)
-     and is_surface_night(entity.surface)
+     and is_surface_night(entity.surface, entity.position)
      and not has_overtime_exemption(entity) then
     reason = "night"
   end
@@ -424,11 +441,16 @@ function M.update_managed_buildings()
       storage.working_hours_state[unit_number] = nil
       storage.working_hours_protest_claims[unit_number] = nil
     else
-      local surface_id = entity.surface.index
-      local surface_is_night = surface_night_cache[surface_id]
-      if surface_is_night == nil then
-        surface_is_night = is_surface_night(entity.surface)
-        surface_night_cache[surface_id] = surface_is_night
+      -- Resolve before caching: buildings sharing a surface can sit inside
+      -- different sealed interiors, and so answer to different planets.
+      local outside, dark = time_of_day_surface(entity.surface, entity.position)
+      local surface_is_night = true
+      if not dark then
+        surface_is_night = surface_night_cache[outside.index]
+        if surface_is_night == nil then
+          surface_is_night = outside.valid and surface_daytime_is_night(outside) or false
+          surface_night_cache[outside.index] = surface_is_night
+        end
       end
 
       local reason = nil
@@ -445,8 +467,8 @@ function M.update_managed_buildings()
   end
 end
 
-function M.is_night(surface)
-  return is_surface_night(surface)
+function M.is_night(surface, position)
+  return is_surface_night(surface, position)
 end
 
 function M.entity_has_overtime_exemption(entity)

--- a/tests/test_compat_hooks.lua
+++ b/tests/test_compat_hooks.lua
@@ -1,0 +1,106 @@
+-------------------------------------------------------------------------------
+-- COMPATIBILITY HOOK ENGINE TESTS
+-------------------------------------------------------------------------------
+
+local passed, failed, errors = 0, 0, {}
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    passed = passed + 1
+  else
+    failed = failed + 1
+    errors[#errors + 1] = name .. ": " .. tostring(err)
+  end
+end
+
+local function assert_eq(actual, expected, message)
+  if actual ~= expected then
+    error((message or "assertion failed") .. ": expected " .. tostring(expected) .. ", got " .. tostring(actual), 2)
+  end
+end
+
+local mod_root = debug.getinfo(1, "S").source:match("@(.*/)")
+if mod_root then
+  mod_root = mod_root:gsub("Internal/tests/$", ""):gsub("tests/$", "")
+else
+  mod_root = "./"
+end
+package.path = mod_root .. "?.lua;" .. mod_root .. "?/init.lua;" .. package.path
+
+local hooks = require("compat.hooks")
+
+test("an unregistered point resolves to nil so the caller keeps its default", function()
+  hooks.reset()
+
+  assert_eq(hooks.resolve("time_of_day_surface", "surface"), nil, "nobody answered")
+end)
+
+test("the first handler with an answer wins", function()
+  hooks.reset()
+  hooks.register("point", function() return nil end)
+  hooks.register("point", function(value) return value .. "-first" end)
+  hooks.register("point", function(value) return value .. "-second" end)
+
+  assert_eq(hooks.resolve("point", "x"), "x-first", "registration order decides")
+end)
+
+test("a handler can pass a second value along", function()
+  hooks.reset()
+  hooks.register("point", function() return "surface", true end)
+
+  local answer, extra = hooks.resolve("point")
+  assert_eq(answer, "surface", "first return value")
+  assert_eq(extra, true, "second return value")
+end)
+
+test("handlers of one point do not answer another", function()
+  hooks.reset()
+  hooks.register("point", function() return "answer" end)
+
+  assert_eq(hooks.resolve("other_point"), nil, "points are independent")
+end)
+
+test("collect unions every registered set into the base", function()
+  hooks.reset()
+  hooks.register("set", function() return {b = true} end)
+  hooks.register("set", function() return {c = true} end)
+
+  local collected = hooks.collect("set", {a = true})
+  assert_eq(collected.a, true, "base entries survive")
+  assert_eq(collected.b, true, "first handler contributes")
+  assert_eq(collected.c, true, "second handler contributes")
+end)
+
+test("collect on an unregistered point returns the base untouched", function()
+  hooks.reset()
+  local base = {a = true}
+
+  assert_eq(hooks.collect("set", base), base, "the base table itself comes back")
+  assert_eq(next(base), "a", "with nothing added")
+end)
+
+test("registering after the point was read is a hard error", function()
+  hooks.reset()
+  hooks.collect("set", {})
+
+  local ok, err = pcall(hooks.register, "set", function() return {} end)
+  assert_eq(ok, false, "a late registration must not be silently dropped")
+  assert_eq(err:find("already read") ~= nil, true, "the error names the cause: " .. tostring(err))
+end)
+
+test("reading one point does not seal another", function()
+  hooks.reset()
+  hooks.resolve("point")
+
+  hooks.register("other_point", function() return "answer" end)
+  assert_eq(hooks.resolve("other_point"), "answer", "unrelated points stay open")
+end)
+
+print(("Compat hook tests: %d passed, %d failed"):format(passed, failed))
+if failed > 0 then
+  for _, err in ipairs(errors) do
+    print(" - " .. err)
+  end
+  os.exit(1)
+end

--- a/tests/test_factorissimo_compat.lua
+++ b/tests/test_factorissimo_compat.lua
@@ -1,0 +1,50 @@
+-------------------------------------------------------------------------------
+-- FACTORISSIMO COMPATIBILITY TESTS
+-------------------------------------------------------------------------------
+
+local passed, failed, errors = 0, 0, {}
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if ok then
+    passed = passed + 1
+  else
+    failed = failed + 1
+    errors[#errors + 1] = name .. ": " .. tostring(err)
+  end
+end
+
+local function assert_eq(actual, expected, message)
+  if actual ~= expected then
+    error((message or "assertion failed") .. ": expected " .. tostring(expected) .. ", got " .. tostring(actual), 2)
+  end
+end
+
+local mod_root = debug.getinfo(1, "S").source:match("@(.*/)")
+if mod_root then
+  mod_root = mod_root:gsub("Internal/tests/$", ""):gsub("tests/$", "")
+else
+  mod_root = "./"
+end
+package.path = mod_root .. "?.lua;" .. mod_root .. "?/init.lua;" .. package.path
+
+local hooks = require("compat.hooks")
+require("compat.factorissimo.runtime")
+
+test("the module registers the factory wall pumps as traversable", function()
+  local collected = hooks.collect("tube_traversable_entities", {["pneumatic-pipe"] = true})
+
+  assert_eq(collected["pneumatic-pipe"], true, "the core entries survive")
+  assert_eq(collected["factory-inside-pump-input"], true, "inside pump is traversable")
+  assert_eq(collected["factory-inside-pump-output"], true, "inside pump is traversable")
+  assert_eq(collected["factory-outside-pump-input"], true, "outside pump is traversable")
+  assert_eq(collected["factory-outside-pump-output"], true, "outside pump is traversable")
+end)
+
+print(("Factorissimo compatibility tests: %d passed, %d failed"):format(passed, failed))
+if failed > 0 then
+  for _, err in ipairs(errors) do
+    print(" - " .. err)
+  end
+  os.exit(1)
+end

--- a/tests/test_factorissimo_compat.lua
+++ b/tests/test_factorissimo_compat.lua
@@ -29,7 +29,178 @@ end
 package.path = mod_root .. "?.lua;" .. mod_root .. "?/init.lua;" .. package.path
 
 local hooks = require("compat.hooks")
-require("compat.factorissimo.runtime")
+local factorissimo = require("compat.factorissimo.runtime")
+
+-- Factorissimo freezes the daytime of a factory floor: noon with the interior
+-- lights upgrade, midnight without.
+local LIT_FLOOR = 1
+local DARK_FLOOR = 0.5
+
+local function new_surface(index, daytime)
+  return {valid = true, index = index, daytime = daytime, dusk = 0.25, dawn = 0.75}
+end
+
+local function new_factory(outside_surface, lights_researched)
+  return {
+    force = {
+      valid = true,
+      technologies = {["factory-interior-upgrade-lights"] = {researched = lights_researched}},
+    },
+    outside_surface = outside_surface,
+    outside_x = 10,
+    outside_y = 20,
+  }
+end
+
+--- factories_by_surface: surface index -> factory enclosing everything on it.
+--- methods: interface listing, defaults to a complete one.
+local function mock_remote(factories_by_surface, methods)
+  local calls = 0
+  remote = {
+    interfaces = {
+      factorissimo = methods or {
+        is_factorissimo_surface = true,
+        find_surrounding_factory_by_surface_index = true,
+      },
+    },
+    call = function(_, method, surface_index)
+      calls = calls + 1
+      if method == "is_factorissimo_surface" then
+        return factories_by_surface[surface_index] ~= nil
+      end
+      if method == "find_surrounding_factory_by_surface_index" then
+        return factories_by_surface[surface_index]
+      end
+      error("unexpected factorissimo call: " .. tostring(method))
+    end,
+  }
+  return function() return calls end
+end
+
+local ORIGIN = {x = 0, y = 0}
+
+test("a lit factory resolves to its outside surface", function()
+  local nauvis = new_surface(1, 0.5)
+  mock_remote({[2] = new_factory(nauvis, true)})
+
+  local outside, unlit = factorissimo.resolve_outside_surface(new_surface(2, LIT_FLOOR), ORIGIN)
+
+  assert_eq(outside, nauvis, "a lit factory should hand back the surface it stands on")
+  assert_eq(unlit, false, "a lit factory is not dark")
+  remote = nil
+end)
+
+test("an unlit factory reports itself as dark", function()
+  local floor = new_surface(2, DARK_FLOOR)
+  mock_remote({[2] = new_factory(new_surface(1, 0.0), false)})
+
+  local outside, unlit = factorissimo.resolve_outside_surface(floor, ORIGIN)
+
+  assert_eq(outside, floor, "an unlit factory stops the walk at its own floor")
+  assert_eq(unlit, true, "a factory without the interior lights upgrade is dark")
+  remote = nil
+end)
+
+test("nested factories resolve to the outermost surface", function()
+  local nauvis = new_surface(1, 0.5)
+  local outer_floor = new_surface(2, LIT_FLOOR)
+  mock_remote({
+    [3] = new_factory(outer_floor, true),
+    [2] = new_factory(nauvis, true),
+  })
+
+  local outside, unlit = factorissimo.resolve_outside_surface(new_surface(3, LIT_FLOOR), ORIGIN)
+
+  assert_eq(outside, nauvis, "the walk should continue out of every enclosing factory")
+  assert_eq(unlit, false, "lit factories all the way out are not dark")
+  remote = nil
+end)
+
+test("an unlit factory outside a lit one still reports dark", function()
+  local outer_floor = new_surface(2, DARK_FLOOR)
+  mock_remote({
+    [3] = new_factory(outer_floor, true),
+    [2] = new_factory(new_surface(1, 0.0), false),
+  })
+
+  local _, unlit = factorissimo.resolve_outside_surface(new_surface(3, LIT_FLOOR), ORIGIN)
+
+  assert_eq(unlit, true, "a dark factory anywhere on the way out counts as dark")
+  remote = nil
+end)
+
+test("a surface with no enclosing factory comes back unchanged", function()
+  local nauvis = new_surface(1, 0.5)
+  mock_remote({})
+
+  local outside, unlit = factorissimo.resolve_outside_surface(nauvis, ORIGIN)
+
+  assert_eq(outside, nauvis, "a plain surface should not be rewritten")
+  assert_eq(unlit, false, "a plain surface is not dark")
+  remote = nil
+end)
+
+test("without factorissimo the surface comes back unchanged", function()
+  local nauvis = new_surface(1, 0.5)
+  remote = {interfaces = {}}
+
+  local outside, unlit = factorissimo.resolve_outside_surface(nauvis, ORIGIN)
+
+  assert_eq(outside, nauvis, "no factorissimo means no resolution")
+  assert_eq(unlit, false, "no factorissimo means never dark")
+  assert_eq(factorissimo.available(), false, "the interface is absent")
+  remote = nil
+end)
+
+test("an older factorissimo without the needed methods is never called", function()
+  local floor = new_surface(2, LIT_FLOOR)
+  local calls = mock_remote({[2] = new_factory(new_surface(1, 0.5), true)}, {get_factory_by_entity = true})
+
+  local outside, unlit = factorissimo.resolve_outside_surface(floor, ORIGIN)
+
+  assert_eq(outside, floor, "an unusable interface behaves like an absent one")
+  assert_eq(unlit, false, "an unusable interface never reports dark")
+  assert_eq(calls(), 0, "remote.call must not run against a missing method")
+  assert_eq(factorissimo.available(), false, "an incomplete interface is not available")
+  remote = nil
+end)
+
+test("a missing position or surface is handled", function()
+  local floor = new_surface(2, LIT_FLOOR)
+  local calls = mock_remote({[2] = new_factory(new_surface(1, 0.5), true)})
+
+  local outside = factorissimo.resolve_outside_surface(floor, nil)
+  assert_eq(outside, floor, "without a position there is nothing to resolve")
+  assert_eq(calls(), 0, "a missing position should not reach the interface")
+
+  local invalid = {valid = false}
+  assert_eq(factorissimo.resolve_outside_surface(invalid, ORIGIN), invalid, "an invalid surface is handed straight back")
+  assert_eq(factorissimo.resolve_outside_surface(nil, ORIGIN), nil, "a nil surface is handed straight back")
+  remote = nil
+end)
+
+-------------------------------------------------------------------------------
+-- HOOK REGISTRATION
+-------------------------------------------------------------------------------
+
+test("the module registers itself into the time of day point", function()
+  local nauvis = new_surface(1, 0.5)
+  mock_remote({[2] = new_factory(nauvis, true)})
+
+  local outside, unlit = hooks.resolve("time_of_day_surface", new_surface(2, LIT_FLOOR), ORIGIN)
+
+  assert_eq(outside, nauvis, "the core should reach the resolution through the hook")
+  assert_eq(unlit, false, "a lit factory is not dark")
+  remote = nil
+end)
+
+test("the time of day point declines a surface it has nothing to say about", function()
+  mock_remote({})
+
+  assert_eq(hooks.resolve("time_of_day_surface", new_surface(1, 0.5), ORIGIN), nil,
+    "a plain surface must fall through to the core default instead of being rewritten")
+  remote = nil
+end)
 
 test("the module registers the factory wall pumps as traversable", function()
   local collected = hooks.collect("tube_traversable_entities", {["pneumatic-pipe"] = true})

--- a/tests/test_pneumatic_runtime.lua
+++ b/tests/test_pneumatic_runtime.lua
@@ -36,6 +36,10 @@ else
 end
 package.path = mod_root .. "?.lua;" .. mod_root .. "?/init.lua;" .. package.path
 
+-- Compat modules register their traversable entities before pneumatic.lua
+-- collects them, exactly as control.lua orders it.
+require("compat.init").load("runtime")
+
 package.loaded["scripts.pneumatic"] = nil
 local pneumatic = require("scripts.pneumatic")
 

--- a/tests/test_working_hours.lua
+++ b/tests/test_working_hours.lua
@@ -155,6 +155,61 @@ test("hard mode attackers do not keep working-hours protest shutdown claims", fu
   assert_eq(storage.working_hours_state[breakroom.unit_number].reason, nil, "hard-mode attackers should not leave a protest shutdown reason")
 end)
 
+-------------------------------------------------------------------------------
+-- SEALED INTERIORS (the resolution itself lives in test_factorissimo_compat)
+-------------------------------------------------------------------------------
+
+test("desk inside a lit factory shuts down when it is night outside", function()
+  storage = {}
+  package.loaded["feature_flags"] = nil
+  package.loaded["compat.hooks"] = nil
+  package.loaded["compat.factorissimo.runtime"] = nil
+  package.loaded["scripts.working_hours"] = nil
+  -- Same order as control.lua: compat registers, then the core module loads.
+  require("compat.init").load("runtime")
+  local working_hours = require("scripts.working_hours")
+
+  -- Factorissimo freezes a lit factory floor at noon; the planet outside it is
+  -- at midnight.
+  local factory = {
+    force = {
+      valid = true,
+      technologies = {["factory-interior-upgrade-lights"] = {researched = true}},
+    },
+    outside_surface = {valid = true, index = 1, daytime = 0.5, dusk = 0.25, dawn = 0.75},
+    outside_x = 10,
+    outside_y = 20,
+  }
+  remote = {
+    interfaces = {
+      factorissimo = {
+        is_factorissimo_surface = true,
+        find_surrounding_factory_by_surface_index = true,
+      },
+    },
+    call = function(_, method, surface_index)
+      if method == "is_factorissimo_surface" then return surface_index == 2 end
+      return surface_index == 2 and factory or nil
+    end,
+  }
+
+  local desk = new_entity("office-desk")
+  desk.surface = {valid = true, index = 2, daytime = 1, dusk = 0.25, dawn = 0.75}
+  desk.position = {x = 0, y = 0}
+  working_hours.refresh_entity(desk)
+
+  assert_eq(desk.active, false, "desk inside a factory should close for the night")
+  assert_eq(storage.working_hours_state[desk.unit_number].reason, "night", "desk inside a factory should record a night shutdown")
+
+  working_hours.update_managed_buildings()
+  assert_eq(desk.active, false, "the periodic update should keep the desk closed")
+
+  remote = nil
+  package.loaded["compat.hooks"] = nil
+  package.loaded["compat.factorissimo.runtime"] = nil
+  package.loaded["scripts.working_hours"] = nil
+end)
+
 print(("Working hours tests: %d passed, %d failed"):format(passed, failed))
 if failed > 0 then
   for _, err in ipairs(errors) do


### PR DESCRIPTION
## Why

While working on Factorissimo compatibility I kept having to edit the logic of core files — foreign entity names ended up hardcoded in the tube network BFS, and the day/night check needed to know about factory interiors.

That does not scale: every new mod means another core file learns another mod's names.

So this PR adds a single compatibility engine. Core files no longer name any mod — they read a **hook point** and keep their own default answer, while compat modules register handlers into those points at load time.

> A new mod that fits an existing hook point costs **zero lines outside `compat/`**.

## What's in it

### 🔧 Moved in: pneumatic tubes through Factorissimo walls

The existing fix, relocated with no behaviour change:

- `prototypes/final_fixes/factorissimo_pneumatic.lua` → `compat/factorissimo/data.lua`
- the four wall-pump names leave `scripts/pneumatic.lua` for `compat/factorissimo/runtime.lua`, which registers them into `tube_traversable_entities`

### 🌙 New: day/night inside a factory

Factorissimo freezes the daytime of its factory floors — noon with the interior lights upgrade, midnight without — so a day-gated building inside a factory never saw the real time of day. **A clerk desk in a lit factory worked around the clock.**

The compat module now answers `time_of_day_surface` by walking out to the enclosing factory's outside surface, through nested factories, and reports a factory *without* the lights upgrade as dark — so lights stay a requirement for working. Interior lighting itself is untouched.

## The seam

**Core side** — the default answer stays here:

```lua
-- scripts/working_hours.lua
local function time_of_day_surface(surface, position)
  local outside, dark = hooks.resolve("time_of_day_surface", surface, position)
  if outside == nil then return surface, false end   -- nobody answered
  return outside, dark or false
end
```

**Compat side:**

```lua
-- compat/factorissimo/runtime.lua
hooks.register("time_of_day_surface", function(surface, position)
  if not M.available() then return nil end          -- "not my case"
  local outside, unlit = M.resolve_outside_surface(surface, position)
  if outside == surface and not unlit then return nil end
  return outside, unlit
end)
```

Set-shaped points work the same way, merged once at load time so hot loops keep indexing a plain table:

```lua
-- scripts/pneumatic.lua
local TRAVERSABLE_NETWORK_ENTITIES = hooks.collect("tube_traversable_entities", {
  ["pneumatic-pipe"] = true,
  ["pneumatic-pipe-to-ground"] = true,
  ["pneumatic-hidden-network-pipe"] = true,
})
```

## How it works

`compat/hooks.lua` holds the handlers registered for each named point:

| Function | Behaviour |
| --- | --- |
| `resolve(point, ...)` | Tries handlers in registration order, takes the first non-`nil` answer. `nil` means *"not my case"*, so several mods can share one point without fighting. |
| `collect(point, base)` | Unions every registered set into the core's base table, once, at load time. The result stays a plain table — no call overhead per BFS step. |
| `register(point, fn)` | Called by compat modules at load time. Registering into a point that was **already read** is a hard error: a silent misordering would silently disable compatibility. |

`compat/init.lua` is the one static list of which compat modules exist and in which stage they run — Factorio cannot enumerate a directory — required once from `control.lua` and once from `data-final-fixes.lua`.

Each compat module gates itself on its own mod being present, so with the mod absent the vanilla path is a single table lookup and behaves exactly as before.

### Hook points so far

| Point | Kind | Question |
| --- | --- | --- |
| `time_of_day_surface` | `resolve` | Which surface carries the real time of day for a building here, and is the spot dark regardless? |
| `tube_traversable_entities` | `collect` | Which foreign entities may a pneumatic tube network walk through? |

## Footprint in core files

**8 lines total** — 4 of them the two seams, 2 the `require` lines:

| File | Change |
| --- | --- |
| `control.lua` | `+1` — load compat modules before `scripts/*` |
| `data-final-fixes.lua` | `~1` — one loader line instead of a direct require |
| `scripts/pneumatic.lua` | `+1` require, `hooks.collect(...)` wrapper, **`−4`** foreign entity names |
| `scripts/working_hours.lua` | `+1` require, the `time_of_day_surface` seam, night cache keyed by the resolved surface, optional `position` |
| `scripts/biter_station.lua` · `scripts/biterport.lua` | `1` line each — pass `position` |

`scripts/` now contains no foreign entity, technology, or interface name.

## Tests

- [x] `tests/test_compat_hooks.lua` — engine: first-wins ordering, point isolation, set merging, late-registration error
- [x] `tests/test_factorissimo_compat.lua` — surface resolution incl. nested factories, unlit factories, mod absent, older mod without the needed remote methods, and that requiring the module registers it into both points
- [x] `tests/test_working_hours.lua` — regression: a desk inside a lit factory closes for the night
- [x] Full suite green

## Docs

📄 **`Internal/docs/mod-compatibility.md`** — the engine, the existing hook points, and a step-by-step for adding your own compatibility module.
